### PR TITLE
Add FromJSON/ToJSON instances to basic types

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -21,6 +21,7 @@ description:         Perpetual Haskelling Initiative
 dependencies:
 - base 
 - text
+- aeson
 
 library:
   source-dirs: src

--- a/package.yaml
+++ b/package.yaml
@@ -27,6 +27,8 @@ library:
   source-dirs: src
   ghc-options:
       - -W
+  default-extensions:
+  - DeriveGeneric
 
 executables:
   phi:

--- a/perpetual-haskelling-initiative.cabal
+++ b/perpetual-haskelling-initiative.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.31.2.
+-- This file has been generated from package.yaml by hpack version 0.33.0.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 761cbe82b849f9f64e714aed5304013cc80dea18ba6a0f374fded373e4f0e79e
+-- hash: f9d81f4c239066eb737a10ea5e98fc02627d8c27fa0fa5c3245375a7e784f3da
 
 name:           perpetual-haskelling-initiative
 version:        0.1.0.0
@@ -24,6 +24,24 @@ source-repository head
   type: git
   location: https://github.com/fpclass/perpetual-haskelling-initiative
 
+library
+  exposed-modules:
+      Purestone
+      Purestone.Card
+      Purestone.Hand
+      Purestone.Language.Program
+      Purestone.Paradigm
+  other-modules:
+      Paths_perpetual_haskelling_initiative
+  hs-source-dirs:
+      src
+  ghc-options: -W
+  build-depends:
+      aeson
+    , base
+    , text
+  default-language: Haskell2010
+
 executable phi
   main-is: Main.hs
   other-modules:
@@ -32,5 +50,7 @@ executable phi
       app
   ghc-options: -threaded -rtsopts -with-rtsopts=-N -Wall
   build-depends:
-      base
+      aeson
+    , base
+    , text
   default-language: Haskell2010

--- a/perpetual-haskelling-initiative.cabal
+++ b/perpetual-haskelling-initiative.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 4e49777432f44208f0c859d292441dd2b8cd47b9b515ff7f8428889f7ecebca5
+-- hash: 4482b983ce4606cf293d2ce6644cb868bd972fadbaeb4d5992daef29800f33f0
 
 name:           perpetual-haskelling-initiative
 version:        0.1.0.0
@@ -29,6 +29,7 @@ library
       Purestone
       Purestone.Card
       Purestone.Hand
+      Purestone.JSON
       Purestone.Language.Program
       Purestone.Paradigm
   other-modules:

--- a/perpetual-haskelling-initiative.cabal
+++ b/perpetual-haskelling-initiative.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: f9d81f4c239066eb737a10ea5e98fc02627d8c27fa0fa5c3245375a7e784f3da
+-- hash: 4e49777432f44208f0c859d292441dd2b8cd47b9b515ff7f8428889f7ecebca5
 
 name:           perpetual-haskelling-initiative
 version:        0.1.0.0
@@ -35,6 +35,7 @@ library
       Paths_perpetual_haskelling_initiative
   hs-source-dirs:
       src
+  default-extensions: DeriveGeneric
   ghc-options: -W
   build-depends:
       aeson

--- a/src/Purestone/Card.hs
+++ b/src/Purestone/Card.hs
@@ -4,6 +4,7 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
+{-# LANGUAGE DeriveGeneric #-}
 
 module Purestone.Card ( Card(..) ) where 
 
@@ -11,6 +12,8 @@ module Purestone.Card ( Card(..) ) where
 
 import Data.List.NonEmpty
 import Data.Text
+import Data.Aeson
+import GHC.Generics
 
 import Purestone.Paradigm
 import Purestone.Language.Program
@@ -27,6 +30,9 @@ data Card = Card {
     cardParadigms :: NonEmpty Paradigm,
     -- | The card's program.
     cardProgram :: Program
-} deriving (Eq, Show)
+} deriving (Eq, Show, Read, Generic)
+
+instance FromJSON Card
+instance ToJSON Card
 
 -------------------------------------------------------------------------------

--- a/src/Purestone/Card.hs
+++ b/src/Purestone/Card.hs
@@ -4,8 +4,6 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
-{-# LANGUAGE DeriveGeneric #-}
-
 module Purestone.Card ( Card(..) ) where 
 
 -------------------------------------------------------------------------------
@@ -30,7 +28,7 @@ data Card = Card {
     cardParadigms :: NonEmpty Paradigm,
     -- | The card's program.
     cardProgram :: Program
-} deriving (Eq, Show, Read, Generic)
+} deriving (Eq, Show, Generic)
 
 instance FromJSON Card
 instance ToJSON Card

--- a/src/Purestone/Card.hs
+++ b/src/Purestone/Card.hs
@@ -15,6 +15,7 @@ import GHC.Generics
 
 import Purestone.Paradigm
 import Purestone.Language.Program
+import Purestone.JSON
 
 -------------------------------------------------------------------------------
 
@@ -30,7 +31,12 @@ data Card = Card {
     cardProgram :: Program
 } deriving (Eq, Show, Generic)
 
-instance FromJSON Card
-instance ToJSON Card
+
+-- Define FromJSON and ToJSON instances for Card. genericParseJSON jsonOpts automatically 
+-- derives instance using the field name with the card prefix removed as the key
+instance FromJSON Card where
+    parseJSON = genericParseJSON jsonOpts
+instance ToJSON Card where
+    toJSON = genericToJSON jsonOpts
 
 -------------------------------------------------------------------------------

--- a/src/Purestone/JSON.hs
+++ b/src/Purestone/JSON.hs
@@ -1,0 +1,24 @@
+module Purestone.JSON (jsonOpts) where
+
+import Data.Aeson
+import Data.Char (isLower, isUpper, toLower)
+
+-- These are currently only used in Purestone.Card however they could be useful for future modules 
+-- and including them in Purestone.Card causes a lot of conflicts with imports (for example dropWhile
+-- could be from Prelude, Data.Text or Data.List.NonEmpty)
+
+-- | `jsonOpts` defines an option for use with genericFromJSON/genericToJSON which configures
+--   the formatting of the field name
+jsonOpts :: Options
+jsonOpts = defaultOptions {
+    fieldLabelModifier = toFieldName
+}
+
+-- | `toFieldName` takes a string name and strips the first word of the camel case. It is used 
+--   to remove the prefix on record field names for JSON instances
+toFieldName :: String -> String
+toFieldName = while isUpper toLower . dropWhile isLower
+    where while _ _ [] = []
+          while p f (x:xs)
+            | p x       = f x : while p f xs
+            | otherwise = x : xs

--- a/src/Purestone/JSON.hs
+++ b/src/Purestone/JSON.hs
@@ -11,7 +11,8 @@ import Data.Char (isLower, isUpper, toLower)
 --   the formatting of the field name
 jsonOpts :: Options
 jsonOpts = defaultOptions {
-    fieldLabelModifier = toFieldName
+    fieldLabelModifier = toFieldName,
+    tagSingleConstructors = True
 }
 
 -- | `toFieldName` takes a string name and strips the first word of the camel case. It is used 

--- a/src/Purestone/Language/Program.hs
+++ b/src/Purestone/Language/Program.hs
@@ -10,6 +10,7 @@ module Purestone.Language.Program ( Program, Instr(..) ) where
 -------------------------------------------------------------------------------
 import GHC.Generics
 import Data.Aeson
+import Purestone.JSON
 -------------------------------------------------------------------------------
 
 -- | A program is a list of instructions.
@@ -20,6 +21,8 @@ data Instr
     = NoOp
     deriving (Eq, Show, Generic)
 
-instance FromJSON Instr
-instance ToJSON Instr
+instance FromJSON Instr where
+    parseJSON = genericParseJSON jsonOpts
+instance ToJSON Instr where
+    toJSON = genericToJSON jsonOpts
 -------------------------------------------------------------------------------

--- a/src/Purestone/Language/Program.hs
+++ b/src/Purestone/Language/Program.hs
@@ -4,8 +4,6 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
-{-# LANGUAGE DeriveGeneric #-}
-
 -- | This module contains representations of 
 module Purestone.Language.Program ( Program, Instr(..) ) where 
 
@@ -21,7 +19,7 @@ type Program = [Instr]
 -- | Represents instructions that can be used to program cards with.
 data Instr 
     = NoOp 
-    deriving (Eq, Show, Read, Generic)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON Instr
 instance ToJSON Instr

--- a/src/Purestone/Language/Program.hs
+++ b/src/Purestone/Language/Program.hs
@@ -4,10 +4,13 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
+{-# LANGUAGE DeriveGeneric #-}
 
 -- | This module contains representations of 
 module Purestone.Language.Program ( Program, Instr(..) ) where 
 
+import GHC.Generics
+import Data.Aeson
 -------------------------------------------------------------------------------
 
 -------------------------------------------------------------------------------
@@ -18,6 +21,8 @@ type Program = [Instr]
 -- | Represents instructions that can be used to program cards with.
 data Instr 
     = NoOp 
-    deriving (Eq, Show)
+    deriving (Eq, Show, Read, Generic)
 
+instance FromJSON Instr
+instance ToJSON Instr
 -------------------------------------------------------------------------------

--- a/src/Purestone/Language/Program.hs
+++ b/src/Purestone/Language/Program.hs
@@ -7,10 +7,9 @@
 -- | This module contains representations of 
 module Purestone.Language.Program ( Program, Instr(..) ) where 
 
+-------------------------------------------------------------------------------
 import GHC.Generics
 import Data.Aeson
--------------------------------------------------------------------------------
-
 -------------------------------------------------------------------------------
 
 -- | A program is a list of instructions.
@@ -18,7 +17,7 @@ type Program = [Instr]
 
 -- | Represents instructions that can be used to program cards with.
 data Instr 
-    = NoOp 
+    = NoOp
     deriving (Eq, Show, Generic)
 
 instance FromJSON Instr

--- a/src/Purestone/Paradigm.hs
+++ b/src/Purestone/Paradigm.hs
@@ -4,8 +4,6 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
-{-# LANGUAGE DeriveGeneric #-}
-
 module Purestone.Paradigm ( Paradigm(..) ) where 
 
 import GHC.Generics
@@ -26,7 +24,7 @@ data Paradigm
     | Compiled
     | Pure 
     | Impure
-    deriving (Eq, Show, Read, Generic)
+    deriving (Eq, Show, Generic)
 
 instance FromJSON Paradigm
 instance ToJSON Paradigm

--- a/src/Purestone/Paradigm.hs
+++ b/src/Purestone/Paradigm.hs
@@ -4,9 +4,12 @@
 -- This source code is licensed under the MIT licence found in the           --
 -- LICENSE file in the root directory of this source tree.                   --
 -------------------------------------------------------------------------------
+{-# LANGUAGE DeriveGeneric #-}
 
 module Purestone.Paradigm ( Paradigm(..) ) where 
 
+import GHC.Generics
+import Data.Aeson
 -------------------------------------------------------------------------------
 
 -- | Enumerates card paradigms.
@@ -23,6 +26,8 @@ data Paradigm
     | Compiled
     | Pure 
     | Impure
-    deriving (Eq, Show)
+    deriving (Eq, Show, Read, Generic)
 
+instance FromJSON Paradigm
+instance ToJSON Paradigm
 -------------------------------------------------------------------------------


### PR DESCRIPTION
This PR adds FromJSON/ToJSON instances for the types introduced in the `feature/basic-types` branch (derived automatically using the `DeriveGeneric` extension)